### PR TITLE
add assertEnd to ConditionalExpression, CatchClause

### DIFF
--- a/src/elements/types/CatchClause.js
+++ b/src/elements/types/CatchClause.js
@@ -20,7 +20,7 @@ export default class CatchClause extends Node {
         children.skipNonCode();
 
         let body = children.passStatement('BlockStatement');
-        children.skipNonCode();
+        children.assertEnd();
 
         this._param = param;
         this._body = body;

--- a/src/elements/types/ConditionalExpression.js
+++ b/src/elements/types/ConditionalExpression.js
@@ -22,7 +22,7 @@ export default class ConditionalExpression extends Expression {
         children.skipNonCode();
 
         let alternate = children.passExpression();
-        children.skipNonCode();
+        children.assertEnd();
 
         this._test = test;
         this._consequent = consequent;

--- a/test/lib/elements/types/ConditionalExpression.js
+++ b/test/lib/elements/types/ConditionalExpression.js
@@ -1,4 +1,5 @@
 import {parseAndGetExpression} from '../../../utils';
+import Token from '../../../../src/elements/Token';
 import {expect} from 'chai';
 
 describe('ConditionalExpression', () => {
@@ -24,5 +25,12 @@ describe('ConditionalExpression', () => {
         expect(expression.consequent.name).to.equal('y');
         expect(expression.alternate.type).to.equal('Identifier');
         expect(expression.alternate.name).to.equal('z');
+    });
+
+    it('should not accept trailing whitespace', () => {
+        var expression = parseAndGetExpression('x ? y : z');
+        expect(() => {
+            expression.appendChild(new Token('Whitespace', '   '));
+        }).to.throw('Expected end of node list but "Whitespace" found');
     });
 });

--- a/test/lib/elements/types/TryStatement.js
+++ b/test/lib/elements/types/TryStatement.js
@@ -1,4 +1,5 @@
 import {parseAndGetStatement} from '../../../utils';
+import Token from '../../../../src/elements/Token';
 import {expect} from 'chai';
 
 describe('TryStatement', () => {
@@ -18,5 +19,12 @@ describe('TryStatement', () => {
         expect(statement.handler.param.name).to.equal('e');
         expect(statement.handler.body.body[0].expression.name).to.equal('y');
         expect(statement.finalizer.body[0].expression.name).to.equal('z');
+    });
+
+    it('should not accept trailing whitespace', () => {
+        var statement = parseAndGetStatement('try { x; } catch ( e ) { y; } finally { z; }');
+        expect(() => {
+            statement.appendChild(new Token('Whitespace', '   '));
+        }).to.throw('Expected end of node list but "Whitespace" found');
     });
 });


### PR DESCRIPTION
Is there a reason why these don't have `assertEnd`?