### PR TITLE
add RestElement

### DIFF
--- a/src/elementTree.js
+++ b/src/elementTree.js
@@ -57,7 +57,7 @@ const visitorKeys = {
     /*IT*/ ObjectPattern: ['properties'],
     /*IT*/ Program: ['body'],
     /*IT*/ Property: ['key', 'value'],
-    /*--*/ RestElement: ['argument'],
+    /*IT*/ RestElement: ['argument'],
     /*IT*/ ReturnStatement: ['argument'],
     /*IT*/ SequenceExpression: ['expressions'],
     /*--*/ SpreadElement: ['argument'],

--- a/src/elements/elementIndex.js
+++ b/src/elements/elementIndex.js
@@ -33,6 +33,7 @@ import ObjectExpression from './types/ObjectExpression';
 import ObjectPattern from './types/ObjectPattern';
 import Program from './types/Program';
 import Property from './types/Property';
+import RestElement from './types/RestElement';
 import ReturnStatement from './types/ReturnStatement';
 import SequenceExpression from './types/SequenceExpression';
 import Super from './types/Super';
@@ -85,6 +86,7 @@ export default {
     ObjectPattern,
     Program,
     Property,
+    RestElement,
     ReturnStatement,
     SequenceExpression,
     Super,

--- a/src/elements/types/RestElement.js
+++ b/src/elements/types/RestElement.js
@@ -1,0 +1,34 @@
+import Node from '../Node';
+
+export default class RestElement extends Node {
+
+    // TODO: Requires a function?
+
+    constructor(childNodes) {
+        super('RestElement', childNodes);
+    }
+
+    _acceptChildren(children) {
+        let argument = null;
+
+        children.passToken('Punctuator', '...');
+
+        children.skipNonCode();
+
+        children.assertPattern();
+        argument = children.currentElement;
+        children.moveNext();
+
+        children.assertEnd();
+
+        this._argument = argument;
+    }
+
+    get argument() {
+        return this._argument;
+    }
+
+    isPattern() {
+        return true;
+    }
+}

--- a/test/lib/elements/types/RestElement.js
+++ b/test/lib/elements/types/RestElement.js
@@ -1,0 +1,39 @@
+import {parseAndGetStatementInFunctionParams} from '../../../utils';
+import {expect} from 'chai';
+
+describe('RestElement', () => {
+    it('should yield correct type', () => {
+        expect(parseAndGetStatementInFunctionParams('...a')[0].type).to.equal('RestElement');
+    });
+
+    it('should accept a single identifier', () => {
+        var statement = parseAndGetStatementInFunctionParams('...a')[0];
+        expect(statement.type).to.equal('RestElement');
+        expect(statement.argument.type).to.equal('Identifier');
+        expect(statement.argument.name).to.equal('a');
+    });
+
+    it('should accept a single identifier with whitespace in between', () => {
+        var statement = parseAndGetStatementInFunctionParams('... a')[0];
+        expect(statement.type).to.equal('RestElement');
+        expect(statement.argument.type).to.equal('Identifier');
+        expect(statement.argument.name).to.equal('a');
+    });
+
+    it('should accept a single identifier with a comment in between', () => {
+        var statement = parseAndGetStatementInFunctionParams('... /* adsf */ a')[0];
+        expect(statement.type).to.equal('RestElement');
+        expect(statement.argument.type).to.equal('Identifier');
+        expect(statement.argument.name).to.equal('a');
+    });
+
+    it('should allow other params on the left', () => {
+        var statements = parseAndGetStatementInFunctionParams('a, ...b');
+        expect(statements[0].type).to.equal('Identifier');
+        expect(statements[0].name).to.equal('a');
+
+        expect(statements[1].type).to.equal('RestElement');
+        expect(statements[1].argument.type).to.equal('Identifier');
+        expect(statements[1].argument.name).to.equal('b');
+    });
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -61,6 +61,12 @@ export function parseAndGetStatementInFunction(code) {
     return program.body[0].body.body[0];
 }
 
+export function parseAndGetStatementInFunctionParams(code) {
+    var parser = new Parser();
+    var program = parser.parse(`function _name(${code}){}`);
+    return program.body[0].params;
+}
+
 export function parseAndGetExpressionInGenerator(code) {
     var parser = new Parser();
     var program = parser.parse(`function * _name(){(${code});}`);


### PR DESCRIPTION
So I'm not sure I know what I'm doing - if it's right then I can do SpreadElement too.

I was going to add 
```js
    it('shouldn\'t allow multiple RestElements', () => {
        expect(() => parseAndGetStatementInFunctionParams('...a, ...b')).to.throw(SyntaxError);
    });
```

but I guess those are for babel to error on