### PR TITLE
SpreadProperty

### DIFF
--- a/src/elementTree.js
+++ b/src/elementTree.js
@@ -61,6 +61,7 @@ const visitorKeys = {
     /*IT*/ ReturnStatement: ['argument'],
     /*IT*/ SequenceExpression: ['expressions'],
     /*IT*/ SpreadElement: ['argument'],
+    /*IT*/ SpreadProperty: ['argument'],
     /*IT*/ Super: [],
     /*IT*/ SwitchStatement: ['discriminant', 'cases'],
     /*IT*/ SwitchCase: ['test', 'consequent'],

--- a/src/elements/elementIndex.js
+++ b/src/elements/elementIndex.js
@@ -40,6 +40,7 @@ import RestElement from './types/RestElement';
 import ReturnStatement from './types/ReturnStatement';
 import SequenceExpression from './types/SequenceExpression';
 import SpreadElement from './types/SpreadElement';
+import SpreadProperty from './types/SpreadProperty';
 import Super from './types/Super';
 import SwitchCase from './types/SwitchCase';
 import SwitchStatement from './types/SwitchStatement';
@@ -97,6 +98,7 @@ export default {
     ReturnStatement,
     SequenceExpression,
     SpreadElement,
+    SpreadProperty,
     Super,
     SwitchCase,
     SwitchStatement,

--- a/src/elements/types/ObjectExpression.js
+++ b/src/elements/types/ObjectExpression.js
@@ -6,7 +6,7 @@ export default class ObjectExpression extends Expression {
     }
 
     _acceptChildren(children) {
-        var properties = [];
+        let properties = [];
 
         children.passToken('Punctuator', '{');
         children.skipNonCode();
@@ -17,7 +17,11 @@ export default class ObjectExpression extends Expression {
                 children.skipNonCode();
                 children.assertToken('Punctuator', '}');
             } else {
-                properties.push(children.passNode('Property'));
+                if (children.isNode('SpreadProperty')) {
+                    properties.push(children.passNode('SpreadProperty'));
+                } else {
+                    properties.push(children.passNode('Property'));
+                }
                 children.skipNonCode();
                 if (children.isToken('Punctuator', ',')) {
                     children.moveNext();

--- a/src/elements/types/ObjectPattern.js
+++ b/src/elements/types/ObjectPattern.js
@@ -15,7 +15,11 @@ export default class ObjectPattern extends Node {
                 children.skipNonCode();
                 children.assertToken('Punctuator', '}');
             } else {
-                properties.push(children.passNode('Property'));
+                if (children.isNode('SpreadProperty')) {
+                    properties.push(children.passNode('SpreadProperty'));
+                } else {
+                    properties.push(children.passNode('Property'));
+                }
                 children.skipNonCode();
                 if (children.isToken('Punctuator', ',')) {
                     children.moveNext();

--- a/src/elements/types/SpreadProperty.js
+++ b/src/elements/types/SpreadProperty.js
@@ -1,8 +1,8 @@
 import Node from '../Node';
 
-export default class SpreadElement extends Node {
+export default class SpreadProperty extends Node {
     constructor(childNodes) {
-        super('SpreadElement', childNodes);
+        super('SpreadProperty', childNodes);
     }
 
     _acceptChildren(children) {

--- a/test/lib/elements/types/SpreadProperty.js
+++ b/test/lib/elements/types/SpreadProperty.js
@@ -1,0 +1,67 @@
+import {
+    parseAndGetObjectProperty,
+    parseAndGetStatement
+} from '../../../utils';
+import {expect} from 'chai';
+
+describe('SpreadProperty', () => {
+    it('should yield correct type', () => {
+        // SpreadProperty
+        expect(parseAndGetObjectProperty('...b').type).to.equal('SpreadProperty');
+        // Will be a RestProperty
+        let properties = parseAndGetStatement('let {...a} = b;').declarations[0].id.properties;
+        expect(properties[0].type).to.equal('SpreadProperty');
+    });
+
+    it('should accept a single identifier', () => {
+        let spreadProperty = parseAndGetObjectProperty('...b');
+        expect(spreadProperty.type).to.equal('SpreadProperty');
+        expect(spreadProperty.argument.type).to.equal('Identifier');
+        expect(spreadProperty.argument.name).to.equal('b');
+
+        // Will be a RestProperty
+        let properties = parseAndGetStatement('let {...a} = b;').declarations[0].id.properties;
+        expect(properties[0].type).to.equal('SpreadProperty');
+        expect(properties[0].argument.type).to.equal('Identifier');
+        expect(properties[0].argument.name).to.equal('a');
+    });
+
+    it('should accept a single identifier with a comment in between', () => {
+        let spreadProperty = parseAndGetObjectProperty('... /* a */ b');
+        expect(spreadProperty.type).to.equal('SpreadProperty');
+        expect(spreadProperty.argument.type).to.equal('Identifier');
+        expect(spreadProperty.argument.name).to.equal('b');
+
+        // Will be a RestProperty
+        let properties = parseAndGetStatement('let {... /* a */ a} = b;').declarations[0].id.properties;
+        expect(properties[0].type).to.equal('SpreadProperty');
+        expect(properties[0].argument.type).to.equal('Identifier');
+        expect(properties[0].argument.name).to.equal('a');
+    });
+
+    it('should allow other params', () => {
+        let properties = parseAndGetStatement('let a = { b, ... c, ... d } ;').declarations[0].init.properties;
+        expect(properties[0].type).to.equal('Property');
+        expect(properties[0].key.type).to.equal('Identifier');
+        expect(properties[0].key.name).to.equal('b');
+        expect(properties[0].value.type).to.equal('Identifier');
+        expect(properties[0].value.name).to.equal('b');
+        expect(properties[1].type).to.equal('SpreadProperty');
+        expect(properties[1].argument.type).to.equal('Identifier');
+        expect(properties[1].argument.name).to.equal('c');
+        expect(properties[2].type).to.equal('SpreadProperty');
+        expect(properties[2].argument.type).to.equal('Identifier');
+        expect(properties[2].argument.name).to.equal('d');
+
+        // Will be a RestProperty
+        properties = parseAndGetStatement('let { a, ... b } = c ;').declarations[0].id.properties;
+        expect(properties[0].type).to.equal('Property');
+        expect(properties[0].key.type).to.equal('Identifier');
+        expect(properties[0].key.name).to.equal('a');
+        expect(properties[0].value.type).to.equal('Identifier');
+        expect(properties[0].value.name).to.equal('a');
+        expect(properties[1].type).to.equal('SpreadProperty');
+        expect(properties[1].argument.type).to.equal('Identifier');
+        expect(properties[1].argument.name).to.equal('b');
+    });
+});


### PR DESCRIPTION
Fixes #51 (links and more info there)

Will become `SpreadProperty` (ObjectExpression) and `RestProperty` (ObjectPattern) in babel 6