### PR TITLE
Trailing Commas in function parameter lists, and CallExpression

### DIFF
--- a/src/elements/types/CallExpression.js
+++ b/src/elements/types/CallExpression.js
@@ -14,16 +14,21 @@ export default class CallExpression extends Expression {
         children.passToken('Punctuator', '(');
         children.skipNonCode();
 
-        if (!children.isToken('Punctuator', ')')) {
-            args.push(children.passExpressionOrSpreadElement());
-            children.skipNonCode();
-            while (!children.isToken('Punctuator', ')')) {
-                children.passToken('Punctuator', ',');
+        while (!children.isToken('Punctuator', ')')) {
+            if (children.isToken('Punctuator', ',')) {
+                children.moveNext();
                 children.skipNonCode();
+                children.assertToken('Punctuator', ')');
+            } else {
                 args.push(children.passExpressionOrSpreadElement());
                 children.skipNonCode();
+                if (children.isToken('Punctuator', ',')) {
+                    children.moveNext();
+                    children.skipNonCode();
+                }
             }
         }
+
         children.passToken('Punctuator', ')');
         children.assertEnd();
 

--- a/src/elements/types/utils/getFunctionParams.js
+++ b/src/elements/types/utils/getFunctionParams.js
@@ -8,14 +8,18 @@ export default function getFunctionParams(children) {
     let params = [];
     children.passToken('Punctuator', '(');
     children.skipNonCode();
-    if (!children.isToken('Punctuator', ')')) {
-        params.push(children.passPattern());
-        children.skipNonCode();
-        while (!children.isToken('Punctuator', ')')) {
-            children.passToken('Punctuator', ',');
+    while (!children.isToken('Punctuator', ')')) {
+        if (children.isToken('Punctuator', ',')) {
+            children.moveNext();
             children.skipNonCode();
+            children.assertToken('Punctuator', ')');
+        } else {
             params.push(children.passPattern());
             children.skipNonCode();
+            if (children.isToken('Punctuator', ',')) {
+                children.moveNext();
+                children.skipNonCode();
+            }
         }
     }
     children.passToken('Punctuator', ')');

--- a/test/lib/elements/types/ArrowFunctionExpression.js
+++ b/test/lib/elements/types/ArrowFunctionExpression.js
@@ -68,6 +68,16 @@ describe('ArrowFunctionExpression', () => {
         expect(expression.generator).to.equal(false);
     });
 
+    it('should accept multiple arguments and a trailing comma', () => {
+        var expression = parseAndGetExpression('(( x , y , ) => (1))');
+        expect(expression.params.length).to.equal(2);
+        expect(expression.params[0].type).to.equal('Identifier');
+        expect(expression.params[0].name).to.equal('x');
+        expect(expression.params[1].type).to.equal('Identifier');
+        expect(expression.params[1].name).to.equal('y');
+        expect(expression.generator).to.equal(false);
+    });
+
     it('should accept array pattern', () => {
         var expression = parseAndGetExpression('(([x]) => (1))');
         expect(expression.params.length).to.equal(1);

--- a/test/lib/elements/types/CallExpression.js
+++ b/test/lib/elements/types/CallExpression.js
@@ -31,6 +31,16 @@ describe('CallExpression', () => {
         expect(expression.arguments[1].name).to.equal('y');
     });
 
+    it('should accept multiple arguments with a trailing comma', () => {
+        var expression = parseAndGetExpression('x ( x , y , )');
+        expect(expression.callee.name).to.equal('x');
+        expect(expression.arguments.length).to.equal(2);
+        expect(expression.arguments[0].type).to.equal('Identifier');
+        expect(expression.arguments[0].name).to.equal('x');
+        expect(expression.arguments[1].type).to.equal('Identifier');
+        expect(expression.arguments[1].name).to.equal('y');
+    });
+
     it('should accept multiple arguments with parentheses', () => {
         var expression = parseAndGetExpression('x ( (x) , (y) )');
         expect(expression.callee.name).to.equal('x');

--- a/test/lib/elements/types/FunctionDeclaration.js
+++ b/test/lib/elements/types/FunctionDeclaration.js
@@ -42,6 +42,16 @@ describe('FunctionDeclaration', () => {
         expect(expression.generator).to.equal(false);
     });
 
+    it('should accept multiple arguments and a trailing comma', () => {
+        var expression = parseAndGetStatement('function func ( x , y , ) { }');
+        expect(expression.params.length).to.equal(2);
+        expect(expression.params[0].type).to.equal('Identifier');
+        expect(expression.params[0].name).to.equal('x');
+        expect(expression.params[1].type).to.equal('Identifier');
+        expect(expression.params[1].name).to.equal('y');
+        expect(expression.generator).to.equal(false);
+    });
+
     it('should accept array pattern', () => {
         var expression = parseAndGetStatement('function func ( [ x ] ) { ; }');
         expect(expression.params.length).to.equal(1);

--- a/test/lib/elements/types/FunctionExpression.js
+++ b/test/lib/elements/types/FunctionExpression.js
@@ -42,6 +42,16 @@ describe('FunctionExpression', () => {
         expect(expression.generator).to.equal(false);
     });
 
+    it('should accept multiple arguments and a trailing comma', () => {
+        var expression = parseAndGetExpression('(function ( x , y , ) { })');
+        expect(expression.params.length).to.equal(2);
+        expect(expression.params[0].type).to.equal('Identifier');
+        expect(expression.params[0].name).to.equal('x');
+        expect(expression.params[1].type).to.equal('Identifier');
+        expect(expression.params[1].name).to.equal('y');
+        expect(expression.generator).to.equal(false);
+    });
+
     it('should accept array pattern', () => {
         var expression = parseAndGetExpression('(function ( [ x ] ) { ; })');
         expect(expression.params.length).to.equal(1);


### PR DESCRIPTION
Fixes #55

Just a copy of https://github.com/cst/cst/blob/1ea3f1fccb197a26afa295d79993bcdf1053a1a5/src/elements/types/ObjectPattern.js#L12-L25

```js
        while (!children.isToken('Punctuator', '}')) {
            if (children.isToken('Punctuator', ',')) {
                children.moveNext();
                children.skipNonCode();
                children.assertToken('Punctuator', '}');
            } else {
                properties.push(children.passNode('Property')); // push to array here
                children.skipNonCode();
                if (children.isToken('Punctuator', ',')) {
                    children.moveNext();
                    children.skipNonCode();
                }
            }
        }
```