### PR TITLE
AwaitExpression: remove await*

### DIFF
--- a/src/elements/types/AwaitExpression.js
+++ b/src/elements/types/AwaitExpression.js
@@ -12,31 +12,18 @@ export default class AwaitExpression extends Expression {
         children.passToken('Identifier', 'await');
 
         let argument = null;
-        let all = false;
 
         if (!children.isEnd) {
             children.skipNonCode();
-
-            if (children.isToken('Punctuator', '*')) {
-                children.passToken();
-                children.skipNonCode();
-                all = true;
-            }
-
             argument = children.passExpression();
         }
 
         children.assertEnd();
 
         this._argument = argument;
-        this._all = all;
     }
 
     get argument() {
         return this._argument;
-    }
-
-    get all() {
-        return this._all;
     }
 }

--- a/test/lib/elements/types/AwaitExpression.js
+++ b/test/lib/elements/types/AwaitExpression.js
@@ -5,7 +5,6 @@ describe('AwaitExpression', () => {
 
     it('should return correct type', () => {
         expect(parseAndGetExpressionInAsyncFunction('await 1').type).to.equal('AwaitExpression');
-        expect(parseAndGetExpressionInAsyncFunction('await* 1').type).to.equal('AwaitExpression');
     });
 
     it('should accept argument', () => {
@@ -18,15 +17,6 @@ describe('AwaitExpression', () => {
     it('should accept function call', () => {
         var statement = parseAndGetExpressionInAsyncFunction('await a()');
         expect(statement.type).to.equal('AwaitExpression');
-        expect(statement.argument.type).to.equal('CallExpression');
-        expect(statement.argument.callee.type).to.equal('Identifier');
-        expect(statement.argument.callee.name).to.equal('a');
-    });
-
-    it('should accept all (*)', () => {
-        var statement = parseAndGetExpressionInAsyncFunction('await* a()');
-        expect(statement.type).to.equal('AwaitExpression');
-        expect(statement.all).to.equal(true);
         expect(statement.argument.type).to.equal('CallExpression');
         expect(statement.argument.callee.type).to.equal('Identifier');
         expect(statement.argument.callee.name).to.equal('a');


### PR DESCRIPTION
> Removed await *

https://github.com/tc39/tc39-notes/blob/21a0b0ed8a51995ac94391d7c7674fba110e4044/es7/2015-07/july-30.md#64-advance-async-functions-to-stage-2

https://github.com/babel/babel/issues/2466