### PR TITLE
Remove async ArrowFunctionExpression

### DIFF
--- a/src/elements/types/ArrowFunctionExpression.js
+++ b/src/elements/types/ArrowFunctionExpression.js
@@ -8,13 +8,6 @@ export default class ArrowFunctionExpression extends Expression {
 
     _acceptChildren(children) {
         let params = [];
-        let async = false;
-
-        if (children.isToken('Identifier', 'async')) {
-            async = true;
-            children.passToken('Identifier', 'async');
-            children.skipNonCode();
-        }
 
         if (children.isToken('Punctuator', '(')) {
             params = getFunctionParams(children);
@@ -39,14 +32,9 @@ export default class ArrowFunctionExpression extends Expression {
 
         children.assertEnd();
 
-        this._async = async;
         this._params = params;
         this._body = body;
         this._expression = expression;
-    }
-
-    get async() {
-        return this._async;
     }
 
     get params() {

--- a/test/lib/elements/types/ArrowFunctionExpression.js
+++ b/test/lib/elements/types/ArrowFunctionExpression.js
@@ -91,10 +91,4 @@ describe('ArrowFunctionExpression', () => {
         expect(expression.params[0].type).to.equal('ObjectPattern');
         expect(expression.generator).to.equal(false);
     });
-
-    it('should support async', () => {
-        var expression = parseAndGetExpression('(async ({x}) => (1))');
-        expect(expression.type).to.equal('ArrowFunctionExpression');
-        expect(expression.async).to.equal(true);
-    });
 });


### PR DESCRIPTION
**(wait till babel 6 is released to merge)**

Remove async ArrowFunctionExpression