### PR TITLE
Should not throw for "Identifier" which presented as a "Keyword"

### DIFF
--- a/src/elements/types/Identifier.js
+++ b/src/elements/types/Identifier.js
@@ -8,7 +8,17 @@ export default class Identifier extends Expression {
     }
 
     _acceptChildren(children) {
-        let name = children.passToken('Identifier').value;
+        let name;
+
+        if (children.isToken('Identifier')) {
+            name = children.passToken('Identifier').value;
+
+        // TODO: temporary fix,
+        // until https://github.com/babel/babylon/issues/18 is resolved
+        } else {
+            name = children.passToken('Boolean').value;
+        }
+
         children.assertEnd();
         this.name = name;
     }

--- a/test/lib/elements/Token.js
+++ b/test/lib/elements/Token.js
@@ -1,4 +1,4 @@
-import {parseAndGetProgram} from '../../utils';
+import {parseAndGetProgram, parseAndGetObjectProperty} from '../../utils';
 import Token from '../../../src/elements/Token.js';
 
 import {expect} from 'chai';
@@ -21,6 +21,10 @@ describe('Token', () => {
         let program = parseAndGetProgram('// Hello');
         let token = program.getFirstToken();
         expect(token.type).to.equal('CommentLine');
+    });
+
+    it('should not throw for "Identifier" which presented as a "Keyword" (#108)', () => {
+        expect(parseAndGetObjectProperty('0: 1').type).to.equal('ObjectProperty');
     });
 
     describe('String', () => {


### PR DESCRIPTION
Fixes #108 

/cc @mdevils 