### PR TITLE
Throw `syntaxError` with `loc` property if such error was encountered

### DIFF
--- a/src/elementTree.js
+++ b/src/elementTree.js
@@ -52,7 +52,9 @@ function buildElementTreeItem(ast: Object, state: ElementTreeItemState): ?Elemen
     let childProps = visitorKeys[elementType];
 
     if (!childProps) {
-        throw new Error(`Cannot iterate using ${elementType}`);
+        let error = new SyntaxError(`Cannot iterate using ${elementType}`);
+        error.loc = ast.loc.start;
+        throw error;
     }
 
     let childElements = [];

--- a/test/lib/Parser.js
+++ b/test/lib/Parser.js
@@ -1,0 +1,27 @@
+import Parser from '../../src/Parser';
+import visitorKeys from '../../src/visitorKeys';
+
+import {expect} from 'chai';
+
+describe('Parser::parse', () => {
+    let code;
+
+    beforeEach(() => {
+        code = `class test {
+			render = () => {}
+		}`;
+
+        delete visitorKeys.ClassProperty;
+    });
+
+    it('should iterate by types only', () => {
+        try {
+            new Parser().parse(code);
+            expect(false).to.equal(true);
+
+        } catch (e) {
+            expect(e.message).to.equal('Cannot iterate using ClassProperty');
+            expect(e.loc).to.deep.equal({line: 2, column: 3});
+        }
+    });
+});


### PR DESCRIPTION
Fixes #115