### PR TITLE
Add support for Assignment patterns

### DIFF
--- a/src/elements/types/ObjectProperty.js
+++ b/src/elements/types/ObjectProperty.js
@@ -14,7 +14,9 @@ export default class ObjectProperty extends Node {
         computed = children.isToken('Punctuator', '[');
         key = readKey(children);
 
-        if (children.isEnd && key.type === 'Identifier') {
+        if (children.isNode('AssignmentPattern')) {
+            value = children.passNode();
+        } else if (children.isEnd && key.type === 'Identifier') {
             shorthand = true;
             value = key;
         } else {

--- a/test/lib/elements/types/FunctionDeclaration.js
+++ b/test/lib/elements/types/FunctionDeclaration.js
@@ -66,6 +66,22 @@ describe('FunctionDeclaration', () => {
         expect(expression.generator).to.equal(false);
     });
 
+    it('should accept object pattern with object pattern', () => {
+        var expression = parseAndGetStatement('function func ( { x = 1 } ) { ; }');
+        expect(expression.params.length).to.equal(1);
+        expect(expression.params[0].type).to.equal('ObjectPattern');
+        expect(expression.params[0].properties[0].value.type).to.equal('AssignmentPattern');
+    });
+
+    it('should accept object pattern with assignment pattern', () => {
+        var expression = parseAndGetStatement('function func ( { x = 1 } = 1 ) { ; }');
+        expect(expression.params.length).to.equal(1);
+        expect(expression.params[0].type).to.equal('AssignmentPattern');
+        expect(expression.params[0].left.type).to.equal('ObjectPattern');
+        expect(expression.params[0].left.properties[0].key.type).to.equal('Identifier');
+        expect(expression.params[0].left.properties[0].value.type).to.equal('AssignmentPattern');
+    });
+
     it('should support generator', () => {
         var expression = parseAndGetStatement('function * func ( x ) { ; }');
         expect(expression.generator).to.equal(true);

--- a/test/lib/elements/types/ObjectProperty.js
+++ b/test/lib/elements/types/ObjectProperty.js
@@ -1,4 +1,8 @@
-import {parseAndGetObjectProperty} from '../../../utils';
+import {
+    parseAndGetObjectProperty,
+    parseAndGetObjectPropertyDefaultValue
+} from '../../../utils';
+
 import {expect} from 'chai';
 
 describe('ObjectProperty', () => {
@@ -7,5 +11,12 @@ describe('ObjectProperty', () => {
         expect(property.type).to.equal('ObjectProperty');
         expect(property.key.name).to.equal('x');
         expect(property.value.value).to.equal(1);
+    });
+
+    it('should parse with assignment pattern', () => {
+        const property = parseAndGetObjectPropertyDefaultValue('x = 1');
+        expect(property.type).to.equal('ObjectProperty');
+        expect(property.key.name).to.equal('x');
+        expect(property.value.type).to.equal('AssignmentPattern');
     });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -44,6 +44,13 @@ export function parseAndGetObjectProperty(code: string): Object {
     return program.body[0].expression.properties[0];
 }
 
+export function parseAndGetObjectPropertyDefaultValue(code: string): Object {
+    var parser = new Parser();
+    var program = parser.parse(`({${code}} = {})`);
+
+    return program.body[0].expression.left.properties[0];
+}
+
 export function parseAndGetClassMember(code: string): Object {
     var parser = new Parser();
     var program = parser.parse(`(class{${code}})`);


### PR DESCRIPTION
For these types:
* ({ test = 1 } = {})
* function func ( { x = 1 } ) { ; }
* function func ( { x = 1 } = 1 ) { ; }

Fixes #118

/cc @mdevils 